### PR TITLE
BlockRegen protection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,12 @@ plugins {
     id("com.mineinabyss.conventions.testing")
     kotlin("plugin.serialization")
 }
+
+repositories {
+    maven("https://repo.codemc.org/repository/maven-public/")
+    maven("https://hub.jeff-media.com/nexus/repository/jeff-media-public/") //CustomBlockData
+}
+
 dependencies {
     // MineInAbyss platform
     compileOnly(libs.kotlin.stdlib)
@@ -14,4 +20,12 @@ dependencies {
     compileOnly(libs.exposed.core) { isTransitive = false }
     compileOnly(libs.exposed.dao) { isTransitive = false }
     compileOnly(libs.exposed.jdbc) { isTransitive = false }
+
+    compileOnly(gaealibs.geary.papermc.core)
+    compileOnly(gaealibs.blocky)
+    compileOnly(gaealibs.minecraft.plugin.blocklocker)
+
+    implementation(libs.idofront.core)
+    implementation(gaealibs.minecraft.plugin.customblockdata)
+    implementation(gaealibs.minecraft.plugin.morepersistentdatatypes)
 }

--- a/gradle/gaealibs.versions.toml
+++ b/gradle/gaealibs.versions.toml
@@ -1,0 +1,15 @@
+[versions]
+geary = "0.16.100"
+gearyaddons = "0.6.37"
+looty = "0.7.56"
+blocky = "0.3.32"
+
+[libraries]
+geary-papermc-core = { module = "com.mineinabyss:geary-papermc-core", version.ref = "geary" }
+geary-commons-papermc = { module = "com.mineinabyss:geary-commons-papermc", version.ref = "gearyaddons" }
+looty = { module = "com.mineinabyss:looty", version.ref = "looty" }
+blocky = { module = "com.mineinabyss:blocky", version.ref = "blocky" }
+
+minecraft-plugin-blocklocker = "nl.rutgerkok:blocklocker:1.10.4-SNAPSHOT"
+minecraft-plugin-customblockdata = "com.jeff_media:CustomBlockData:2.0.0"
+minecraft-plugin-morepersistentdatatypes = "com.jeff_media:MorePersistentDataTypes:2.3.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,5 +32,6 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("libs").from("com.mineinabyss:catalog:$idofrontVersion")
+        create("gaealibs").from(files("gradle/gaealibs.versions.toml"))
     }
 }

--- a/src/main/kotlin/org/cultofclang/minecraft/gaea/GaeaPlugin.kt
+++ b/src/main/kotlin/org/cultofclang/minecraft/gaea/GaeaPlugin.kt
@@ -1,8 +1,11 @@
 package org.cultofclang.minecraft.gaea
 
+import com.jeff_media.customblockdata.CustomBlockData
 import org.bukkit.World
 import org.bukkit.plugin.java.JavaPlugin
 import org.cultofclang.minecraft.gaea.commands.InfoCommand
+import org.cultofclang.minecraft.gaea.listeners.ChunkListener
+import org.cultofclang.minecraft.gaea.listeners.TrackedWorld
 import org.cultofclang.utils.parseJson
 import org.cultofclang.utils.readAllToString
 
@@ -22,8 +25,11 @@ class GaeaPlugin : JavaPlugin() {
     override fun onEnable() {
         getCommand("gaea")?.setExecutor(InfoCommand)
         server.pluginManager.registerEvents(ChunkListener, this)
+        server.pluginManager.registerEvents(ProtectionListener, this)
         server.scheduler.scheduleSyncRepeatingTask(this, ChunkListener, 200, 1)
 
+        //CustomBlockData listener
+        CustomBlockData.registerListener(this)
         //logger.info(calcMarket().toString())
 
 

--- a/src/main/kotlin/org/cultofclang/minecraft/gaea/Globals.kt
+++ b/src/main/kotlin/org/cultofclang/minecraft/gaea/Globals.kt
@@ -1,9 +1,10 @@
 package org.cultofclang.minecraft.gaea
 
+import org.bukkit.NamespacedKey
 import org.bukkit.plugin.java.JavaPlugin
 import org.cultofclang.utils.MarketBook
 import org.cultofclang.utils.calcMarket
 
 val Gaea: GaeaPlugin by lazy { JavaPlugin.getPlugin(GaeaPlugin::class.java) }
-
 val Broker: MarketBook by lazy { calcMarket() }
+val ProtectionKey: NamespacedKey = NamespacedKey(Gaea, "regen_protected")

--- a/src/main/kotlin/org/cultofclang/minecraft/gaea/ProtectionListener.kt
+++ b/src/main/kotlin/org/cultofclang/minecraft/gaea/ProtectionListener.kt
@@ -1,0 +1,92 @@
+package org.cultofclang.minecraft.gaea
+
+import com.jeff_media.customblockdata.CustomBlockData
+import com.jeff_media.customblockdata.events.CustomBlockDataMoveEvent
+import com.jeff_media.customblockdata.events.CustomBlockDataRemoveEvent
+import com.jeff_media.morepersistentdatatypes.DataType
+import com.mineinabyss.blocky.helpers.getGearyEntityFromBlock
+import org.bukkit.block.Block
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockPlaceEvent
+import org.cultofclang.minecraft.gaea.components.RegenProtection
+
+object ProtectionListener : Listener {
+
+    //TODO Make this fire when "activating" the protblock not just on placing it
+    // Get all blocks within radius and make them "protected"
+    @EventHandler
+    fun BlockPlaceEvent.onPlaceProtectionBlock() {
+        block.getGearyEntityFromBlock()?.get<RegenProtection>() ?: return
+        blockPlaced.addBlockProtection()
+    }
+
+    // Remove protection from blocks when protblock is removed
+    @EventHandler
+    fun CustomBlockDataRemoveEvent.onProtectionBlockRemoved() {
+        block.getGearyEntityFromBlock()?.get<RegenProtection>() ?: return
+        block.removeBlockProtection()
+    }
+
+    // Get all blocks within radius of moved block and protect them
+    @EventHandler
+    fun CustomBlockDataMoveEvent.onProtectionBlockMoved() {
+        block.getGearyEntityFromBlock()?.get<RegenProtection>() ?: return
+        block.addBlockProtection()
+    }
+
+    // Adds blockprotection to this block
+    private fun Block.addBlockProtection() {
+        val rad = getGearyEntityFromBlock()?.get<RegenProtection>()?.protectionRadius ?: return
+        val loc = location.clone()
+
+        for (x in (loc.blockX - rad..loc.blockX + rad)) {
+            for (y in (loc.blockY - rad..loc.blockY + rad)) {
+                for (z in (loc.blockZ - rad..loc.blockZ + rad)) {
+                    val pdc = CustomBlockData(world.getBlockAt(x, y, z), Gaea)
+
+                    // If it already has another blockprotection, add to array
+                    if (pdc.has(ProtectionKey)) {
+                        val array = pdc.get(ProtectionKey, DataType.LOCATION_ARRAY)
+                        array?.get(array.lastIndex)?.add(location)
+                    } else {
+                        // Otherwise set the key and add originloc
+                        pdc.set(ProtectionKey, DataType.LOCATION_ARRAY, arrayOf(location))
+                    }
+                }
+            }
+        }
+    }
+
+    // Removes a specific protectionblock from this block
+    private fun Block.removeBlockProtection() {
+        val rad = getGearyEntityFromBlock()?.get<RegenProtection>()?.protectionRadius ?: return
+        val loc = location.clone()
+
+        for (x in (loc.blockX - rad..loc.blockX + rad)) {
+            for (y in (loc.blockY - rad..loc.blockY + rad)) {
+                for (z in (loc.blockZ - rad..loc.blockZ + rad)) {
+                    val b = world.getBlockAt(x, y, z)
+                    val pdc = CustomBlockData(b, Gaea)
+                    val locArray = pdc.get(ProtectionKey, DataType.LOCATION_ARRAY) ?: return
+                    if (locArray.contains(location)) {
+                        val newArray = locArray.filter { it != location }.toTypedArray()
+                        if (newArray.isNotEmpty()) pdc.set(ProtectionKey, DataType.LOCATION_ARRAY, newArray)
+                        else pdc.remove(ProtectionKey)
+                    }
+                }
+            }
+        }
+    }
+
+    // Removes all protections from this block
+    private fun Block.clearBlockProtections() {
+        val rad = getGearyEntityFromBlock()?.get<RegenProtection>()?.protectionRadius ?: return
+        val loc = location.clone()
+
+        for (x in (loc.blockX - rad..loc.blockX + rad))
+            for (y in (loc.blockY - rad..loc.blockY + rad))
+                for (z in (loc.blockZ - rad..loc.blockZ + rad))
+                    CustomBlockData(world.getBlockAt(x, y, z), Gaea).remove(ProtectionKey)
+    }
+}

--- a/src/main/kotlin/org/cultofclang/minecraft/gaea/Zone.kt
+++ b/src/main/kotlin/org/cultofclang/minecraft/gaea/Zone.kt
@@ -1,11 +1,15 @@
 package org.cultofclang.minecraft.gaea
 
+import com.jeff_media.customblockdata.CustomBlockData
+import com.mineinabyss.blocky.helpers.getGearyEntityFromBlock
 import org.bukkit.Bukkit
 import org.bukkit.Chunk
 import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.block.Block
 import org.bukkit.entity.Player
+import org.cultofclang.minecraft.gaea.components.RegenProtection
+import org.cultofclang.minecraft.gaea.listeners.TrackedWorld
 import org.cultofclang.utils.*
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
@@ -127,8 +131,13 @@ class Zone(id: EntityID<Long>) : LongEntity(id) {
 
                 zipZoneBlocks(chunk, masterChunk, zone.y) { client: Block, master: Block ->
                     val prob = Gaea.settings.getDecayProbability(client.type)
-
                     if (client.type != master.type) {
+
+                        if (client.getGearyEntityFromBlock()?.has<RegenProtection>() == true ||
+                            CustomBlockData(client, Gaea).has(ProtectionKey)
+                        )
+                            return@zipZoneBlocks // Skip blocks that are "under protection"
+
                         changesToBeMade = true
                         val realProb = 1 - (1 - prob).pow(decayPower)
                         if (bool(realProb)) {

--- a/src/main/kotlin/org/cultofclang/minecraft/gaea/components/RegenProtection.kt
+++ b/src/main/kotlin/org/cultofclang/minecraft/gaea/components/RegenProtection.kt
@@ -1,0 +1,15 @@
+package org.cultofclang.minecraft.gaea.components
+
+import com.mineinabyss.idofront.serialization.DurationSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.time.Duration
+
+@Serializable
+@SerialName("gaea:regen_protection")
+class RegenProtection(
+    val protectionRadius: Int,
+    //TODO Copy this as its only thing needed from Idofront?
+    @Serializable(with = DurationSerializer::class)
+    val protectionStarted: Duration
+)

--- a/src/main/kotlin/org/cultofclang/minecraft/gaea/listeners/ChunkListener.kt
+++ b/src/main/kotlin/org/cultofclang/minecraft/gaea/listeners/ChunkListener.kt
@@ -1,4 +1,4 @@
-package org.cultofclang.minecraft.gaea
+package org.cultofclang.minecraft.gaea.listeners
 
 import net.kyori.adventure.text.Component
 import org.bukkit.Bukkit
@@ -13,6 +13,8 @@ import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.world.ChunkLoadEvent
 import org.bukkit.inventory.ItemStack
+import org.cultofclang.minecraft.gaea.Gaea
+import org.cultofclang.minecraft.gaea.Zone
 import org.cultofclang.utils.CHUNK_HEIGHT
 import org.cultofclang.utils.ZONE_SIZE
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -36,7 +38,7 @@ object ChunkListener : Listener, Runnable {
 
     private var toProcess = ConcurrentLinkedQueue<Chunk>()
 
-    fun addBalance(location: Location, change: Float) {
+    private fun addBalance(location: Location, change: Float) {
         val zone = Zone.get(location) ?: return
         zone.markDirtyAndSetMinBalance(change)
     }

--- a/src/main/kotlin/org/cultofclang/minecraft/gaea/listeners/TrackedWorld.kt
+++ b/src/main/kotlin/org/cultofclang/minecraft/gaea/listeners/TrackedWorld.kt
@@ -1,7 +1,8 @@
-package org.cultofclang.minecraft.gaea
+package org.cultofclang.minecraft.gaea.listeners
 
 import org.bukkit.Bukkit
 import org.bukkit.World
+import org.cultofclang.minecraft.gaea.Zones
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction

--- a/src/main/kotlin/org/cultofclang/utils/Chunk.kt
+++ b/src/main/kotlin/org/cultofclang/utils/Chunk.kt
@@ -4,7 +4,7 @@ import org.bukkit.Chunk
 import org.bukkit.block.Block
 
 
-const val CHUNK_HEIGHT: Int = 256
+const val CHUNK_HEIGHT: Int = 512
 const val CHUNK_WIDTH: Int = 16
 const val ZONE_SIZE: Int = 16
 


### PR DESCRIPTION
Initial draft.
Dont even think this needs to rely on Blocky for this tbh. Could simply be done via plugins adding a key to block PDC but

Not sure on the most performant method.
The events should be called simply when a blocky prot block is removed/moved

The decay will also skip any protected block or protectionblock atm